### PR TITLE
#3 Feat create remaining entity

### DIFF
--- a/src/entities/inventory.ts
+++ b/src/entities/inventory.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Users } from './user';
+import { Item } from './item';
+
+@Entity({ schema: 'todo', name: 'inventory' })
+export class Inventory {
+  @PrimaryColumn()
+  itemOwnerId: number;
+
+  @PrimaryColumn()
+  itemId: number;
+
+  @Column()
+  isUsed: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date | null;
+
+  @ManyToOne(() => Users, (users) => users.id)
+  @JoinColumn([{ name: 'itemOwnerId', referencedColumnName: 'id' }])
+  ItemOwnerID: Users;
+
+  @ManyToOne(() => Item, (item) => item.id)
+  @JoinColumn([{ name: 'itemId', referencedColumnName: 'id' }])
+  ItemId: Item;
+}

--- a/src/entities/item.ts
+++ b/src/entities/item.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity({ schema: 'todo', name: 'item' })
+export class Item {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('varchar', { name: 'comment', length: 32 })
+  name: string;
+
+  @Column()
+  price: number;
+
+  @Column('varchar', { name: 'comment', length: 128 })
+  comment: string;
+
+  @Column('integer', { name: 'buy_count', default: 0 })
+  buyCount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date | null;
+}

--- a/src/entities/like.ts
+++ b/src/entities/like.ts
@@ -33,5 +33,5 @@ export class LikeHistory {
 
   @ManyToOne(() => Schedules, (schedule) => schedule.id)
   @JoinColumn([{ name: 'scheduleOwnerId', referencedColumnName: 'id' }])
-  ScheduleID: Users;
+  ScheduleID: Schedules;
 }

--- a/src/entities/notice.ts
+++ b/src/entities/notice.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Users } from './user';
+
+@Entity({ schema: 'todo', name: 'notice' })
+export class Notice {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  noticeOwnerId: number;
+
+  @Column('varchar', { name: 'desc', length: 512 })
+  desc: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date | null;
+
+  @ManyToOne(() => Users, (user) => user.id)
+  @JoinColumn([{ name: 'noticeOwnerId', referencedColumnName: 'id' }])
+  NoticeOwnerId: Users;
+}


### PR DESCRIPTION
Inventory와 History 엔티티의 역할이 겹치기 때문에 구현하지 않았습니다.
Follow는 Users에 이미 구현되어있었기 때문에 구현하지 않았습니다.